### PR TITLE
DEV: v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "traytoday"
 authors = ["urdekcah <ya@urdekcah.ru>"]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ cargo install traytoday
 ```  
 
 ## Usage
-TrayToday supports the following commands:
-- **`traytoday search <school name>`**: Search for schools by name. If no API key is provided, only up to five results will be displayed.
-- **`traytoday set <school name>`**: Search for a school, select one from the results, and set it as your default school. Without an API key, results are limited to five.
-- **`traytoday`**: Retrieve the meal information for the currently configured school if no options are specified.
+### Primary Commands
+- **`traytoday search <school name>`**: Conduct an erudite search for educational institutions that match the specified name. Note: Without an API key, results are capped at five entries.
+- **`traytoday set <school name>`**: Search for a school, select from the enumerated results, and designate it as your default institution. As with the search command, the absence of an API key limits results to five options.
+- **`traytoday set-key <api key>`**: Set your API key. If you set an incorrect key, an error will occur when using other command.
+- **`traytoday date <date>`**: Retrieve the meal information for a specific date. (e.g. `traytoday date 2025-02-08`, `traytoday date tomorrow`, `traytoday date week`, `traytoday date mon`)
+- **`traytoday`**: Retrieve the meal information for your currently configured school when no additional arguments are provided.
 
+### Flags
+- **`--allergen <ingredient>`**: Specify the allergenic component to monitor. For example, `traytoday --allergen peanut` will trigger a notification if any meal contains peanuts. (only in: `root`, **`date`**) [See all available allergens](doc/reference/allergens.md)
+
+### Examples
 below is an example of how to use TrayToday:
 ```bash
 $ traytoday set 선린인터넷
@@ -32,4 +38,4 @@ $ traytoday
 ```
 
 ## Contact
-For inquiries or bug reports, please use the [Issues section](https://github.com/urdekcah/traytoday/issues) of the project.  
+For inquiries or bug reports, please use the [Issues section](https://github.com/urdekcah/traytoday/issues) of the project.

--- a/doc/reference/allergens.md
+++ b/doc/reference/allergens.md
@@ -1,0 +1,23 @@
+The keys available for use with the `--allergen` option are delineated below. You may specify a singular key (e.g., `--allergen=egg`) or, alternatively, enumerate multiple keys (e.g., `--allergen=egg,milk`).
+
+| Allergen Key                            | Description                            |
+|-----------------------------------------|----------------------------------------|
+| `egg`, `eggs`                           | Eggs                                   |
+| `milk`, `dairy`                         | Dairy products                         |
+| `buckwheat`                             | Buckwheat                              |
+| `peanut`, `peanuts`                     | Peanuts                                |
+| `soy`                                   | Soy products                           |
+| `wheat`                                 | Wheat and gluten-containing products   |
+| `mackerel`                              | Mackerel                               |
+| `crab`                                  | Crab                                   |
+| `shrimp`                                | Shrimp                                 |
+| `pork`                                  | Pork                                   |
+| `peach`                                 | Peach                                  |
+| `tomato`                                | Tomato                                 |
+| `sulfite`, `sulfites`                   | Sulfites                               |
+| `walnut`                                | Walnut                                 |
+| `chicken`                               | Chicken                                |
+| `beef`                                  | Beef                                   |
+| `squid`                                 | Squid                                  |
+| `shellfish`, `clam`, `oyster`, `mussel` | Shellfish                              |
+| `pine nut`                              | Pine Nut                               |

--- a/src/allergens.rs
+++ b/src/allergens.rs
@@ -1,0 +1,58 @@
+use std::{collections::HashMap, io::Write};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::Result;
+pub const ALLERGENS: &[(u8, &str, &[&str])] = &[
+  (1, "난류", &["egg", "eggs"]),
+  (2, "우유", &["milk", "dairy"]),
+  (3, "메밀", &["buckwheat"]),
+  (4, "땅콩", &["peanut", "peanuts"]),
+  (5, "대두", &["soy"]),
+  (6, "밀", &["wheat"]),
+  (7, "고등어", &["mackerel"]),
+  (8, "게", &["crab"]),
+  (9, "새우", &["shrimp"]),
+  (10, "돼지고기", &["pork"]),
+  (11, "복숭아", &["peach"]),
+  (12, "토마토", &["tomato"]),
+  (13, "아황산류", &["sulfite", "sulfites"]),
+  (14, "호두", &["walnut"]),
+  (15, "닭고기", &["chicken"]),
+  (16, "쇠고기", &["beef"]),
+  (17, "오징어", &["squid"]),
+  (18, "조개류", &["shellfish", "clam", "oyster", "mussel"]),
+  (19, "잣", &["pine nut"]),
+];
+
+pub struct AllergenChecker {
+  allergen_map: HashMap<String, u8>,
+}
+
+impl AllergenChecker {
+  pub fn new() -> Self {
+    let mut allergen_map = HashMap::new();
+    for &(num, name, aliases) in ALLERGENS {
+      allergen_map.insert(name.to_lowercase(), num);
+      for alias in aliases {
+        allergen_map.insert(alias.to_lowercase(), num);
+      }
+    }
+    Self { allergen_map }
+  }
+
+  pub fn get_number(&self, name: &str) -> Result<u8> {
+    let result = self
+      .allergen_map
+      .get(&name.to_lowercase())
+      .copied()
+      .unwrap_or(0);
+    if result == 0 {
+      let mut stderr = StandardStream::stderr(ColorChoice::Always);
+      stderr.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Yellow)))?;
+      write!(stderr, "warning")?;
+      stderr.reset()?;
+      write!(stderr, ": Allergen not found ({})\n", name)?;
+    }
+    Ok(result)
+  }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,7 @@ impl NeisClient {
     atpt_code: &str,
     school_code: &str,
     dates: &[String],
-  ) -> Result<Vec<Vec<Meal>>> {
+  ) -> Result<Vec<Meal>> {
     let mut all_meals = Vec::new();
 
     for date in dates {
@@ -55,7 +55,7 @@ impl NeisClient {
 
       self.validate_response(&response)?;
       let meals = self.parse_meals(&response).unwrap_or_default();
-      all_meals.push(meals);
+      all_meals.extend(meals);
     }
 
     Ok(all_meals)

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,91 +24,101 @@ impl NeisClient {
 
   pub async fn search_schools(&self, school_name: &str) -> Result<Vec<School>> {
     let mut url = self.build_school_url()?;
-    url
-      .query_pairs_mut()
-      .append_pair("SCHUL_NM", school_name)
-      .finish();
+    url.query_pairs_mut().append_pair("SCHUL_NM", school_name);
 
-    if let Some(api_key) = &self.config.api_key {
-      url.query_pairs_mut().append_pair("KEY", api_key).finish();
+    self.append_api_key(&mut url);
+    let response = self.get_json_response(url).await?;
+
+    self.validate_response(&response)?;
+    let schools = self.parse_schools(&response).unwrap_or_default();
+    Ok(schools)
+  }
+
+  pub async fn get_meals_for_dates(
+    &self,
+    atpt_code: &str,
+    school_code: &str,
+    dates: &[String],
+  ) -> Result<Vec<Vec<Meal>>> {
+    let mut all_meals = Vec::new();
+
+    for date in dates {
+      let mut url = self.build_meal_url()?;
+      url
+        .query_pairs_mut()
+        .append_pair("ATPT_OFCDC_SC_CODE", atpt_code)
+        .append_pair("SD_SCHUL_CODE", school_code)
+        .append_pair("MLSV_YMD", date);
+
+      self.append_api_key(&mut url);
+      let response = self.get_json_response(url).await?;
+
+      self.validate_response(&response)?;
+      let meals = self.parse_meals(&response).unwrap_or_default();
+      all_meals.push(meals);
     }
 
-    let response: Value = self.client.get(url.as_str()).send().await?.json().await?;
+    Ok(all_meals)
+  }
 
+  fn build_school_url(&self) -> Result<Url> {
+    self.build_base_url(SCHOOL_INFO_ENDPOINT)
+  }
+
+  fn build_meal_url(&self) -> Result<Url> {
+    self.build_base_url(MEAL_SERVICE_ENDPOINT)
+  }
+
+  fn build_base_url(&self, endpoint: &str) -> Result<Url> {
+    let mut url =
+      Url::parse(API_BASE_URL).map_err(|_| Error::ConfigError("Invalid API URL".to_string()))?;
+    url.set_path(endpoint);
+    url.query_pairs_mut().append_pair("Type", "json");
+    Ok(url)
+  }
+
+  fn append_api_key(&self, url: &mut Url) {
+    if let Some(api_key) = &self.config.api_key {
+      url.query_pairs_mut().append_pair("KEY", api_key);
+    }
+  }
+
+  async fn get_json_response(&self, url: Url) -> Result<Value> {
+    let response = self.client.get(url.as_str()).send().await?.json().await?;
+    Ok(response)
+  }
+
+  fn validate_response(&self, response: &Value) -> Result<()> {
     if let Some(result) = response["RESULT"].as_object() {
-      if !["INFO-200", "INFO-000"].contains(&result["CODE"].as_str().unwrap_or("Unknown error")) {
+      let code = result["CODE"].as_str().unwrap_or("Unknown error");
+      if !["INFO-200", "INFO-000"].contains(&code) {
         return Err(Error::ApiError(format!(
-          "API Error: {}",
+          "API Error: {} - {}",
+          code,
           result["MESSAGE"].as_str().unwrap_or("Unknown error")
         )));
       }
     }
+    Ok(())
+  }
 
-    if let Some(result) = response["schoolInfo"][0]["head"][1]["RESULT"].as_object() {
-      if result["CODE"] == "INFO-200" {
-        return Ok(Vec::new());
-      }
-    }
-
+  fn parse_schools(&self, response: &Value) -> Result<Vec<School>> {
     let schools = response["schoolInfo"][1]["row"]
       .as_array()
-      .unwrap_or(&vec![])
+      .ok_or_else(|| Error::ApiError("I think no schools".to_string()))?
       .iter()
-      .map(|school| serde_json::from_value(school.clone()).unwrap())
+      .filter_map(|school| serde_json::from_value(school.clone()).ok())
       .collect();
     Ok(schools)
   }
 
-  pub async fn get_meals(
-    &self,
-    atpt_code: &str,
-    school_code: &str,
-    date: &str,
-  ) -> Result<Vec<Meal>> {
-    let mut url = self.build_meal_url()?;
-    url
-      .query_pairs_mut()
-      .append_pair("ATPT_OFCDC_SC_CODE", atpt_code)
-      .append_pair("SD_SCHUL_CODE", school_code)
-      .append_pair("MLSV_YMD", date)
-      .finish();
-
-    if let Some(api_key) = &self.config.api_key {
-      url.query_pairs_mut().append_pair("KEY", api_key).finish();
-    }
-
-    let response: Value = self.client.get(url.as_str()).send().await?.json().await?;
-    if let Some(result) = response["RESULT"].as_object() {
-      if !["INFO-200", "INFO-000"].contains(&result["CODE"].as_str().unwrap_or("Unknown error")) {
-        return Err(Error::ApiError(format!(
-          "API Error: {}",
-          result["MESSAGE"].as_str().unwrap_or("Unknown error")
-        )));
-      }
-    }
-
+  fn parse_meals(&self, response: &Value) -> Result<Vec<Meal>> {
     let meals = response["mealServiceDietInfo"][1]["row"]
       .as_array()
-      .unwrap_or(&vec![])
+      .ok_or_else(|| Error::ApiError("I think no meals today".to_string()))?
       .iter()
-      .map(|meal| serde_json::from_value(meal.clone()).unwrap())
+      .filter_map(|meal| serde_json::from_value(meal.clone()).ok())
       .collect();
     Ok(meals)
-  }
-
-  fn build_school_url(&self) -> Result<Url> {
-    let mut url =
-      Url::parse(API_BASE_URL).map_err(|_| Error::ConfigError("Invalid API URL".to_string()))?;
-    url.set_path(SCHOOL_INFO_ENDPOINT);
-    url.query_pairs_mut().append_pair("Type", "json");
-    Ok(url)
-  }
-
-  fn build_meal_url(&self) -> Result<Url> {
-    let mut url =
-      Url::parse(API_BASE_URL).map_err(|_| Error::ConfigError("Invalid API URL".to_string()))?;
-    url.set_path(MEAL_SERVICE_ENDPOINT);
-    url.query_pairs_mut().append_pair("Type", "json");
-    Ok(url)
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ pub struct Config {
   pub edu_code: String,
   #[serde(default)]
   pub school_code: String,
+  #[serde(default)]
+  pub api_key: Option<String>,
 }
 
 fn default_language() -> String {
@@ -56,6 +58,7 @@ impl Config {
     self.language = new_config.language;
     self.edu_code = new_config.edu_code;
     self.school_code = new_config.school_code;
+    self.api_key = new_config.api_key;
   }
 }
 
@@ -65,6 +68,7 @@ impl Default for Config {
       language: default_language(),
       edu_code: String::new(),
       school_code: String::new(),
+      api_key: None,
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub enum Error {
   TomlError(#[from] toml::de::Error),
   #[error("TOML serialization error: {0}")]
   TomlSerError(#[from] toml::ser::Error),
+  #[error("API error: {0}")]
+  ApiError(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 pub mod client;
 pub mod config;
 pub mod models;
+pub mod utils;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -22,6 +23,8 @@ pub enum Error {
   TomlSerError(#[from] toml::ser::Error),
   #[error("API error: {0}")]
   ApiError(String),
+  #[error("Date parsing error: {0}")]
+  DateError(#[from] chrono::ParseError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+pub mod allergens;
 pub mod client;
 pub mod config;
 pub mod models;
@@ -25,6 +26,8 @@ pub enum Error {
   ApiError(String),
   #[error("Date parsing error: {0}")]
   DateError(#[from] chrono::ParseError),
+  #[error("Invalid allergen: {0}")]
+  AllergenError(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,13 +96,13 @@ async fn main() -> Result<()> {
       } else {
         let date = chrono::Local::now().format("%Y%m%d").to_string();
         let meals = client
-          .get_meals(&config.edu_code, &config.school_code, &date)
+          .get_meals_for_dates(&config.edu_code, &config.school_code, &[date])
           .await?;
-        if meals.is_empty() {
+        if meals[0].is_empty() {
           println!("No meals found for today.");
         }
         let mut stdout = StandardStream::stdout(ColorChoice::Always);
-        for (i, meal) in meals.iter().enumerate() {
+        for (i, meal) in meals[0].iter().enumerate() {
           stdout
             .set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::White)))
             .map_err(|_| fmt::Error)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,12 +24,18 @@ enum Commands {
     #[arg(help = "School name to set")]
     name: String,
   },
+  #[command(about = "Set API key")]
+  SetKey {
+    #[arg(help = "API key to set")]
+    key: String,
+  },
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
   let args = Cli::parse();
-  let client = NeisClient::new();
+  let config = traytoday::config::Config::load()?;
+  let client = NeisClient::new(&config);
 
   match args.command {
     Some(Commands::Search { name }) => {
@@ -78,8 +84,13 @@ async fn main() -> Result<()> {
       new_config.save()?;
       println!("School set to {}", school.schul_nm);
     }
+    Some(Commands::SetKey { key }) => {
+      let mut new_config = config.clone();
+      new_config.api_key = Some(key);
+      new_config.save()?;
+      println!("API key set");
+    }
     None => {
-      let config = traytoday::config::Config::load()?;
       if config.edu_code.is_empty() || config.school_code.is_empty() {
         println!("No school set. Use `traytoday set` to set your school.");
       } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,83 +51,73 @@ async fn main() -> Result<()> {
   let client = NeisClient::new(&config);
 
   match args.command {
-    Some(Commands::Search { name }) => {
-      let schools = client.search_schools(&name).await?;
-      for (i, school) in schools.iter().enumerate() {
-        println!("============== {} ==============", school.schul_nm);
-        println!("{}", school);
-        if i >= schools.len() - 1 {
-          println!("===============================================");
-        }
-      }
-    }
-    Some(Commands::Set { name }) => {
-      let schools = client.search_schools(&name).await?;
-      let mut stdout = StandardStream::stdout(ColorChoice::Always);
+    Some(Commands::Search { name }) => handle_search_command(&client, name).await?,
+    Some(Commands::Set { name }) => handle_set_school_command(&client, name).await?,
+    Some(Commands::SetKey { key }) => handle_set_key_command(&config, key).await?,
+    Some(Commands::Date(cmd)) => handle_date_command(&client, &config, &cmd).await?,
+    None => handle_root_command(&client, &args, &config).await?,
+  }
 
-      for (i, school) in schools.iter().enumerate() {
-        stdout.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Yellow)))?;
-        write!(&mut stdout, "{}. ", i + 1)?;
-        stdout.reset()?;
-        writeln!(
-          &mut stdout,
-          "{} ({})",
-          school.schul_nm, school.atpt_ofcdc_sc_nm
-        )?;
+  Ok(())
+}
 
-        stdout.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::White)))?;
-        writeln!(&mut stdout, "- {} {}", school.org_rdnma, school.org_rdnda)?;
-        stdout.reset()?;
-      }
-
-      print!("> ");
-      std::io::stdout().flush()?;
-      let mut input = String::new();
-      std::io::stdin().read_line(&mut input)?;
-
-      let index: usize = input.trim().parse()?;
-      let school = schools
-        .get(index - 1)
-        .ok_or_else(|| anyhow::anyhow!("Invalid index"))?;
-
-      let config = traytoday::config::Config::load()?;
-      let mut new_config = config.clone();
-      new_config.edu_code = school.atpt_ofcdc_sc_code.clone();
-      new_config.school_code = school.sd_schul_code.clone();
-      new_config.save()?;
-      println!("School set to {}", school.schul_nm);
-    }
-    Some(Commands::SetKey { key }) => {
-      let mut new_config = config.clone();
-      new_config.api_key = Some(key);
-      new_config.save()?;
-      println!("API key set");
-    }
-    Some(Commands::Date(cmd)) => {
-      handle_date_command(&client, &config, &cmd).await?;
-    }
-    None => {
-      if config.edu_code.is_empty() || config.school_code.is_empty() {
-        println!("No school set. Use `traytoday set` to set your school.");
-      } else {
-        let checker = AllergenChecker::new();
-        let allergen = args.allergen
-          .split(",")
-          .map(|a| a.trim())
-          .map(|a| checker.get_number(a).unwrap_or(0))
-          .collect::<Vec<_>>();
-
-        let date = chrono::Local::now().format("%Y%m%d").to_string();
-        let meals = client
-          .get_meals_for_dates(&config.edu_code, &config.school_code, &[date])
-          .await?;
-        if meals.is_empty() {
-          println!("No meals found for today.");
-        }
-        print_meals(&meals, Some(allergen))?;
-      }
+async fn handle_search_command(client: &NeisClient, name: String) -> Result<()> {
+  let schools = client.search_schools(&name).await?;
+  for (i, school) in schools.iter().enumerate() {
+    println!("============== {} ==============", school.schul_nm);
+    println!("{}", school);
+    if i >= schools.len() - 1 {
+      println!("===============================================");
     }
   }
+
+  Ok(())
+}
+
+async fn handle_set_school_command(client: &NeisClient, name: String) -> Result<()> {
+  let schools = client.search_schools(&name).await?;
+  let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+  for (i, school) in schools.iter().enumerate() {
+    stdout.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Yellow)))?;
+    write!(&mut stdout, "{}. ", i + 1)?;
+    stdout.reset()?;
+    writeln!(
+      &mut stdout,
+      "{} ({})",
+      school.schul_nm, school.atpt_ofcdc_sc_nm
+    )?;
+
+    stdout.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::White)))?;
+    writeln!(&mut stdout, "- {} {}", school.org_rdnma, school.org_rdnda)?;
+    stdout.reset()?;
+  }
+
+  print!("> ");
+  std::io::stdout().flush()?;
+  let mut input = String::new();
+  std::io::stdin().read_line(&mut input)?;
+
+  let index: usize = input.trim().parse()?;
+  let school = schools
+    .get(index - 1)
+    .ok_or_else(|| anyhow::anyhow!("Invalid index"))?;
+
+  let config = traytoday::config::Config::load()?;
+  let mut new_config = config.clone();
+  new_config.edu_code = school.atpt_ofcdc_sc_code.clone();
+  new_config.school_code = school.sd_schul_code.clone();
+  new_config.save()?;
+  println!("School set to {}", school.schul_nm);
+
+  Ok(())
+}
+
+async fn handle_set_key_command(config: &Config, key: String) -> Result<()> {
+  let mut new_config = config.clone();
+  new_config.api_key = Some(key);
+  new_config.save()?;
+  println!("API key set");
 
   Ok(())
 }
@@ -154,6 +144,31 @@ async fn handle_date_command(
     .await?;
 
   print_meals(&meals, Some(allergens))?;
+
+  Ok(())
+}
+
+async fn handle_root_command(client: &NeisClient, args: &Cli, config: &Config) -> Result<()> {
+  if config.edu_code.is_empty() || config.school_code.is_empty() {
+    println!("No school set. Use `traytoday set` to set your school.");
+  } else {
+    let checker = AllergenChecker::new();
+    let allergen = args
+      .allergen
+      .split(",")
+      .map(|a| a.trim())
+      .map(|a| checker.get_number(a).unwrap_or(0))
+      .collect::<Vec<_>>();
+
+    let date = chrono::Local::now().format("%Y%m%d").to_string();
+    let meals = client
+      .get_meals_for_dates(&config.edu_code, &config.school_code, &[date])
+      .await?;
+    if meals.is_empty() {
+      println!("No meals found for today.");
+    }
+    print_meals(&meals, Some(allergen))?;
+  }
 
   Ok(())
 }

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -1,0 +1,52 @@
+use crate::{Error, Result};
+use chrono::{Datelike, Duration, Local, Weekday};
+
+pub fn parse_date(date_str: &str) -> Result<String> {
+  let today = Local::now().date_naive();
+
+  match date_str.to_lowercase().as_str() {
+    "today" => Ok(today.format("%Y%m%d").to_string()),
+    _ => {
+      let date =
+        chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|e| Error::DateError(e))?;
+      Ok(date.format("%Y%m%d").to_string())
+    }
+  }
+}
+
+pub fn get_week_dates() -> Vec<String> {
+  let today = Local::now().date_naive();
+  let weekday = today.weekday();
+
+  let start = today
+    - Duration::days(match weekday {
+      Weekday::Mon => 0,
+      Weekday::Tue => 1,
+      Weekday::Wed => 2,
+      Weekday::Thu => 3,
+      Weekday::Fri => 4,
+      Weekday::Sat => 5,
+      Weekday::Sun => 6,
+    } as i64);
+
+  (0..5)
+    .map(|i| (start + Duration::days(i)).format("%Y%m%d").to_string())
+    .collect()
+}
+
+pub fn print_date_pretty(date: &str) -> Result<String> {
+  let date = chrono::NaiveDate::parse_from_str(date, "%Y%m%d").map_err(|e| Error::DateError(e))?;
+  let weekday = date.weekday();
+  let formatted_date = date.format("%d.%m.%Y");
+  let weekday_str = match weekday {
+    Weekday::Mon => "Mon",
+    Weekday::Tue => "Tue",
+    Weekday::Wed => "Wed",
+    Weekday::Thu => "Thu",
+    Weekday::Fri => "Fri",
+    Weekday::Sat => "Sat",
+    Weekday::Sun => "Sun",
+  };
+
+  Ok(format!("{} ({})", formatted_date, weekday_str))
+}

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -5,7 +5,36 @@ pub fn parse_date(date_str: &str) -> Result<String> {
   let today = Local::now().date_naive();
 
   match date_str.to_lowercase().as_str() {
+    "ereyesterday" => Ok((today - Duration::days(2)).format("%Y%m%d").to_string()),
+    "yesterday" => Ok((today - Duration::days(1)).format("%Y%m%d").to_string()),
     "today" => Ok(today.format("%Y%m%d").to_string()),
+    "tomorrow" => Ok((today + Duration::days(1)).format("%Y%m%d").to_string()),
+    "postmorrow" => Ok((today + Duration::days(2)).format("%Y%m%d").to_string()),
+    "monday" | "tuesday" | "wednesday" | "thursday" | "friday" => {
+      let days_until = match date_str {
+        "monday" => 0,
+        "tuesday" => 1,
+        "wednesday" => 2,
+        "thursday" => 3,
+        "friday" => 4,
+        _ => 0,
+      };
+
+      let date = get_week_dates()[days_until].clone();
+      Ok(date)
+    }
+    "mon" | "tue" | "wed" | "thu" | "fri" => {
+      let days_until = match date_str {
+        "mon" => 0,
+        "tue" => 1,
+        "wed" => 2,
+        "thu" => 3,
+        "fri" => 4,
+        _ => 0,
+      };
+      let date = get_week_dates()[days_until].clone();
+      Ok(date)
+    }
     _ => {
       let date =
         chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|e| Error::DateError(e))?;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod date;


### PR DESCRIPTION
## Added features
- **`traytoday set-key <api key>`**: Set your API key. If you set an incorrect key, an error will occur when using other command.
- **`traytoday date <date>`**: Retrieve the meal information for a specific date. (e.g. `traytoday date 2025-02-08`, `traytoday date tomorrow`, `traytoday date week`, `traytoday date mon`)
### Flags
- **`--allergen <ingredient>`**: Specify the allergenic component to monitor. For example, `traytoday --allergen peanut` will trigger a notification if any meal contains peanuts. (only in: `root`, **`date`**) [See all available allergens](doc/reference/allergens.md)